### PR TITLE
Add MA display toggles to chart

### DIFF
--- a/chart.js
+++ b/chart.js
@@ -861,8 +861,8 @@ function setupTools() {
 
   btnClearHLines.addEventListener('click', () => {
     while (hLines.length > 0) {
-      const line = hLines.pop();
-      try { priceSeries.removePriceLine(line); } catch (_) {}
+      const entry = hLines.pop();
+      try { priceSeries.removePriceLine(entry.line); } catch (_) {}
     }
   });
 
@@ -908,7 +908,7 @@ function setupTools() {
         axisLabelVisible: true,
         title: formatCompactNumber(price),
       });
-      hLines.push(line);
+      hLines.push({ line, price });
       hLineAddActive = false;
       btnAddHLine.classList.remove('btn-active');
       return;
@@ -943,13 +943,13 @@ function setupTools() {
     // H-line proximity
     if (hLines.length > 0) {
       let best = null;
-      for (const line of hLines) {
-        const p = line.options ? line.options().price : null;
+      for (const entry of hLines) {
+        const p = entry.price ?? (entry.line.options ? entry.line.options().price : null);
         if (p == null) continue;
         const py = chart.priceScale('right').priceToCoordinate ? chart.priceScale('right').priceToCoordinate(p) : null;
         if (py == null) continue;
         const diff = Math.abs(py - y);
-        if (!best || diff < best.diff) best = { line, py, diff };
+        if (!best || diff < best.diff) best = { line: entry.line, py, diff };
       }
       if (best && best.diff <= 6) {
         draggingHLine = { line: best.line, offsetY: y - best.py };
@@ -989,8 +989,8 @@ function setupTools() {
           axisLabelVisible: true,
           title: formatCompactNumber(price),
         });
-        const idx = hLines.indexOf(draggingHLine.line);
-        if (idx >= 0) hLines[idx] = newLine;
+        const idx = hLines.findIndex(entry => entry.line === draggingHLine.line);
+        if (idx >= 0) hLines[idx] = { line: newLine, price };
         draggingHLine.line = newLine;
       }
       e.preventDefault();
@@ -1030,8 +1030,8 @@ function setupTools() {
     // H-line proximity
     if (hLines.length > 0) {
       let best = null;
-      for (const line of hLines) {
-        const p = line.options ? line.options().price : null;
+      for (const entry of hLines) {
+        const p = entry.price ?? (entry.line.options ? entry.line.options().price : null);
         if (p == null) continue;
         const py = chart.priceScale('right').priceToCoordinate ? chart.priceScale('right').priceToCoordinate(p) : null;
         if (py == null) continue;
@@ -1078,8 +1078,8 @@ function setupTools() {
           axisLabelVisible: true,
           title: formatCompactNumber(price),
         });
-        const idx = hLines.indexOf(draggingHLine.line);
-        if (idx >= 0) hLines[idx] = newLine;
+        const idx = hLines.findIndex(entry => entry.line === draggingHLine.line);
+        if (idx >= 0) hLines[idx] = { line: newLine, price };
         draggingHLine.line = newLine;
       }
       e.preventDefault();

--- a/chart.js
+++ b/chart.js
@@ -696,9 +696,35 @@ function handlePinchZoom(scaleChange) {
   }
 }
 
+// Bind MA checkbox toggles to series visibility
+function setupMAToggles() {
+  const bindings = [
+    { id: 'toggle-ma20', series: ma20 },
+    { id: 'toggle-ma50', series: ma50 },
+    { id: 'toggle-ma100', series: ma100 },
+    { id: 'toggle-ma200', series: ma200 },
+  ];
+
+  bindings.forEach(({ id, series }) => {
+    const checkbox = document.getElementById(id);
+    if (!checkbox || !series) return;
+
+    // Initialize visibility based on current checkbox state
+    series.applyOptions({ visible: checkbox.checked });
+
+    checkbox.addEventListener('change', (e) => {
+      const target = e.target;
+      series.applyOptions({ visible: !!target.checked });
+    });
+  });
+}
+
 // Initialize everything
 manager.initializeChart().then(() => {
   console.log('🎯 Chart ready with bid spread data and dual y-axis!');
+  
+  // Wire MA toggles
+  setupMAToggles();
   
   // Start update cycle
   manager.startUpdateCycle();

--- a/chart.js
+++ b/chart.js
@@ -563,6 +563,17 @@ function setTimeframe(timeframe) {
   manager.switchTimeframe(timeframe);
 }
 
+// Toggle bottom indicator panel visibility
+window.toggleIndicatorPanel = function toggleIndicatorPanel() {
+  const indicator = document.getElementById('indicator-chart');
+  const main = document.getElementById('main-chart');
+  if (!indicator || !main) return;
+  const willShow = indicator.style.display === 'none' || indicator.style.display === '';
+  indicator.style.display = willShow ? 'block' : 'none';
+  // After layout change, refit main chart content to ensure axes spaces recalc nicely
+  try { window.chart.timeScale().fitContent(); } catch (_) {}
+};
+
 // FIXED: Enhanced zoom functions with MASSIVE zoom range like TradingView
 function zoomIn() {
   if (window.chart) {

--- a/chart.js
+++ b/chart.js
@@ -576,6 +576,7 @@ window.toggleIndicatorPanel = function toggleIndicatorPanel() {
     indicator.style.display = 'none';
   }
   try { window.chart.timeScale().fitContent(); } catch (_) {}
+  console.log('Indicator panel visible:', indicator.style.display === 'block');
 };
 
 // FIXED: Enhanced zoom functions with MASSIVE zoom range like TradingView
@@ -1227,6 +1228,10 @@ manager.initializeChart().then(() => {
 
   // Wire Tools (measure, horizontal lines)
   setupTools();
+
+  // Ensure indicator is hidden at start
+  const ind = document.getElementById('indicator-chart');
+  if (ind) ind.style.display = 'none';
   
   // Start update cycle
   manager.startUpdateCycle();

--- a/chart.js
+++ b/chart.js
@@ -570,10 +570,20 @@ window.toggleIndicatorPanel = function toggleIndicatorPanel() {
   if (!indicator || !main) return;
   const isHidden = indicator.style.display === 'none' || indicator.style.display === '';
   if (isHidden) {
+    // Fix main chart height to remaining space to avoid canvas overlap
+    const container = document.getElementById('chart-container');
+    if (container) {
+      const totalH = container.clientHeight;
+      const indicatorH = Math.round(totalH * 0.20);
+      main.style.height = (totalH - indicatorH) + 'px';
+      main.style.flex = '0 0 auto';
+    }
     indicator.style.display = 'block';
-    // main stays flex:1; indicator has fixed height via CSS
   } else {
     indicator.style.display = 'none';
+    // Restore flex so main fills
+    main.style.height = '';
+    main.style.flex = '1 1 auto';
   }
   try { window.chart.timeScale().fitContent(); } catch (_) {}
   console.log('Indicator panel visible:', indicator.style.display === 'block');

--- a/chart.js
+++ b/chart.js
@@ -1,11 +1,26 @@
 // Simplified Bitcoin Chart - Clean Interface
 // Main price chart with Bid Spread MAs on LEFT y-axis and enhanced zoom capability
 
+// Compact formatters to shrink y-axis label width
+function formatCompactNumber(value) {
+  const sign = value < 0 ? '-' : '';
+  const abs = Math.abs(value);
+  if (abs >= 1e9) return sign + (abs / 1e9).toFixed(abs >= 1e10 ? 0 : 1) + 'B';
+  if (abs >= 1e6) return sign + (abs / 1e6).toFixed(abs >= 1e7 ? 0 : 1) + 'M';
+  if (abs >= 1e3) return sign + (abs / 1e3).toFixed(abs >= 1e4 ? 0 : 1) + 'k';
+  return sign + abs.toFixed(0);
+}
+
+function formatPercent(value) {
+  return (value * 100).toFixed(2) + '%';
+}
+
 // Chart configuration with LEFT/RIGHT dual y-axis and massive zoom range
 window.chart = LightweightCharts.createChart(document.getElementById('main-chart'), {
   layout: {
     background: { color: '#131722' },
     textColor: '#D1D4DC',
+    fontSize: 7,
   },
   grid: {
     vertLines: { color: '#2B2B43' },
@@ -40,7 +55,7 @@ window.chart = LightweightCharts.createChart(document.getElementById('main-chart
     timeVisible: true, 
     secondsVisible: false,
     borderVisible: false,
-    rightOffset: 50,
+    rightOffset: 15,
     barSpacing: 12, // Increased spacing for thicker candlestick bodies
     minBarSpacing: 0.1, // MUCH tighter for extreme zoom out
     fixLeftEdge: false,
@@ -132,6 +147,16 @@ const cumulativeMA = chart.addLineSeries({
   lastValueVisible: false,
   priceLineVisible: false,
 });
+
+// Apply compact price formats to minimize y-axis width
+priceSeries.applyOptions({
+  priceFormat: { type: 'custom', formatter: formatCompactNumber }
+});
+ma20.applyOptions({ priceFormat: { type: 'custom', formatter: formatPercent } });
+ma50.applyOptions({ priceFormat: { type: 'custom', formatter: formatPercent } });
+ma100.applyOptions({ priceFormat: { type: 'custom', formatter: formatPercent } });
+ma200.applyOptions({ priceFormat: { type: 'custom', formatter: formatPercent } });
+cumulativeMA.applyOptions({ priceFormat: { type: 'custom', formatter: formatPercent } });
 
 // Real-time L20 spread line (MA1 - raw data) - REMOVED
 

--- a/chart.js
+++ b/chart.js
@@ -568,9 +568,13 @@ window.toggleIndicatorPanel = function toggleIndicatorPanel() {
   const indicator = document.getElementById('indicator-chart');
   const main = document.getElementById('main-chart');
   if (!indicator || !main) return;
-  const willShow = indicator.style.display === 'none' || indicator.style.display === '';
-  indicator.style.display = willShow ? 'block' : 'none';
-  // After layout change, refit main chart content to ensure axes spaces recalc nicely
+  const isHidden = indicator.style.display === 'none' || indicator.style.display === '';
+  if (isHidden) {
+    indicator.style.display = 'block';
+    // main stays flex:1; indicator has fixed height via CSS
+  } else {
+    indicator.style.display = 'none';
+  }
   try { window.chart.timeScale().fitContent(); } catch (_) {}
 };
 

--- a/chart.js
+++ b/chart.js
@@ -771,6 +771,32 @@ function setupTools() {
   let draggingHLine = null; // { line, offsetY }
   let draggingVLine = null; // { series }
 
+  function setDragInteractions(active) {
+    // Disable chart panning/zooming and crosshair while dragging a line to improve mobile UX
+    if (!window.chart) return;
+    window.chart.applyOptions({
+      handleScroll: {
+        mouseWheel: active,
+        pressedMouseMove: active,
+        horzTouchDrag: active,
+        vertTouchDrag: active,
+      },
+      handleScale: {
+        mouseWheel: active,
+        pinch: active,
+        axisPressedMouseMove: {
+          time: active,
+          price: active,
+        },
+      },
+      crosshair: {
+        mode: LightweightCharts.CrosshairMode.Normal,
+        vertLine: { visible: active },
+        horzLine: { visible: active },
+      },
+    });
+  }
+
   function ensureMeasureLabel() {
     if (measureLabel) return measureLabel;
     const div = document.createElement('div');
@@ -967,6 +993,7 @@ function setupTools() {
         draggingVLine = { series };
         vLineAddActive = false;
         btnAddVLine.classList.remove('btn-active');
+        setDragInteractions(false);
         e.preventDefault();
         return;
       }
@@ -985,6 +1012,7 @@ function setupTools() {
       }
       if (best && best.diff <= 6) {
         draggingHLine = { line: best.line, offsetY: y - best.py };
+        setDragInteractions(false);
         e.preventDefault();
         return;
       }
@@ -1001,6 +1029,7 @@ function setupTools() {
       }
       if (best && best.diff <= 6) {
         draggingVLine = { series: best.v.series };
+        setDragInteractions(false);
         e.preventDefault();
         return;
       }
@@ -1042,6 +1071,7 @@ function setupTools() {
   });
 
   container.addEventListener('mouseup', () => {
+    if (draggingHLine || draggingVLine) setDragInteractions(true);
     draggingHLine = null;
     draggingVLine = null;
   });
@@ -1077,6 +1107,7 @@ function setupTools() {
         draggingVLine = { series };
         vLineAddActive = false;
         btnAddVLine.classList.remove('btn-active');
+        setDragInteractions(false);
         e.preventDefault();
         return;
       }
@@ -1096,6 +1127,7 @@ function setupTools() {
     
       if (best && best.diff <= 20) {
         draggingHLine = { line: best.line, offsetY: 0 };
+        setDragInteractions(false);
         e.preventDefault();
         return;
       }
@@ -1112,6 +1144,7 @@ function setupTools() {
       }
       if (bestV && bestV.diff <= 20) {
         draggingVLine = { series: bestV.v.series };
+        setDragInteractions(false);
         e.preventDefault();
         return;
       }
@@ -1156,6 +1189,7 @@ function setupTools() {
   }, { passive: false });
 
   container.addEventListener('touchend', () => {
+    if (draggingHLine || draggingVLine) setDragInteractions(true);
     draggingHLine = null;
     draggingVLine = null;
   });

--- a/index.html
+++ b/index.html
@@ -78,6 +78,40 @@
       font-weight: 500;
     }
     
+    /* MA toggle controls */
+    #ma-controls {
+      position: absolute;
+      top: 56px;
+      left: 10px;
+      z-index: 100;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      background: rgba(25, 28, 35, 0.9);
+      padding: 8px 12px;
+      border-radius: 8px;
+      backdrop-filter: blur(10px);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      flex-wrap: wrap;
+    }
+
+    .ma-toggle {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      color: #d1d4dc;
+      font-size: 12px;
+      user-select: none;
+      cursor: pointer;
+    }
+
+    .ma-swatch {
+      width: 10px;
+      height: 10px;
+      border-radius: 2px;
+      display: inline-block;
+    }
+    
     /* Mobile optimizations */
     @media (max-width: 768px) {
       #timeframe-controls {
@@ -95,6 +129,15 @@
       .timeframe-label {
         font-size: 11px;
       }
+
+      #ma-controls {
+        top: 46px;
+        left: 5px;
+        padding: 6px 10px;
+        gap: 8px;
+      }
+
+      .ma-toggle { font-size: 11px; }
     }
     
     @media (max-width: 480px) {
@@ -111,6 +154,13 @@
       .timeframe-label {
         font-size: 10px;
       }
+
+      #ma-controls {
+        top: 42px;
+        padding: 4px 8px;
+      }
+
+      .ma-toggle { font-size: 10px; }
     }
   </style>
 </head>
@@ -126,6 +176,29 @@
         <option value="4h">4h</option>
         <option value="1d">1d</option>
       </select>
+    </div>
+
+    <div id="ma-controls">
+      <label class="ma-toggle" title="Toggle MA20 visibility">
+        <input type="checkbox" id="toggle-ma20" checked />
+        <span class="ma-swatch" style="background:#00BFFF"></span>
+        MA20
+      </label>
+      <label class="ma-toggle" title="Toggle MA50 visibility">
+        <input type="checkbox" id="toggle-ma50" checked />
+        <span class="ma-swatch" style="background:#FF6B6B"></span>
+        MA50
+      </label>
+      <label class="ma-toggle" title="Toggle MA100 visibility">
+        <input type="checkbox" id="toggle-ma100" checked />
+        <span class="ma-swatch" style="background:#4ADF86"></span>
+        MA100
+      </label>
+      <label class="ma-toggle" title="Toggle MA200 visibility">
+        <input type="checkbox" id="toggle-ma200" checked />
+        <span class="ma-swatch" style="background:#FFD700"></span>
+        MA200
+      </label>
     </div>
     
     <div id="main-chart"></div>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
       width: 100%;
       flex: 1 1 auto;
       touch-action: pan-x pan-y pinch-zoom;
+      overflow: hidden;
     }
 
     #indicator-chart {

--- a/index.html
+++ b/index.html
@@ -77,90 +77,86 @@
       font-size: 12px;
       font-weight: 500;
     }
-    
-    /* MA toggle controls */
-    #ma-controls {
+
+    /* Floating Tools Button */
+    #tools-button {
       position: absolute;
-      top: 56px;
-      left: 10px;
-      z-index: 100;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      background: rgba(25, 28, 35, 0.9);
-      padding: 8px 12px;
-      border-radius: 8px;
-      backdrop-filter: blur(10px);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      flex-wrap: wrap;
-    }
-
-    .ma-toggle {
-      display: flex;
-      align-items: center;
-      gap: 6px;
+      top: 10px;
+      right: 10px;
+      z-index: 110;
+      background: #2a2e39;
       color: #d1d4dc;
-      font-size: 12px;
-      user-select: none;
+      border: 1px solid #4a4e59;
+      padding: 8px 10px;
+      border-radius: 8px;
       cursor: pointer;
+      font-size: 12px;
+      font-weight: 600;
     }
 
-    .ma-swatch {
-      width: 10px;
-      height: 10px;
-      border-radius: 2px;
-      display: inline-block;
+    #tools-button:hover { background: #363a45; }
+
+    /* Popup Panel */
+    #tools-panel {
+      position: absolute;
+      top: 50px;
+      right: 10px;
+      z-index: 120;
+      width: 240px;
+      background: rgba(25,28,35,0.98);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 10px;
+      padding: 10px;
+      display: none;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+      backdrop-filter: blur(8px);
     }
-    
+
+    .panel-section {
+      margin-bottom: 10px;
+    }
+    .panel-title {
+      color: #9aa0a6;
+      font-size: 11px;
+      font-weight: 700;
+      margin: 6px 0 8px 0;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .ma-toggle { display: flex; align-items: center; gap: 6px; color: #d1d4dc; font-size: 12px; cursor: pointer; }
+    .ma-swatch { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+
+    .btn-row { display: flex; flex-wrap: wrap; gap: 6px; }
+    .btn {
+      background: #2a2e39;
+      border: 1px solid #4a4e59;
+      color: #d1d4dc;
+      padding: 5px 8px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 11px;
+      font-weight: 600;
+    }
+    .btn:hover { background: #363a45; }
+    .btn-danger { border-color: #7a3b3b; color: #ff9a9a; }
+    .btn-danger:hover { background: #3a2a2a; }
+    .btn-active { outline: 2px solid #2962ff55; }
+
     /* Mobile optimizations */
     @media (max-width: 768px) {
-      #timeframe-controls {
-        top: 5px;
-        left: 5px;
-        padding: 6px 10px;
-      }
-      
-      #timeframe-dropdown {
-        font-size: 11px;
-        padding: 4px 8px;
-        min-width: 70px;
-      }
-      
-      .timeframe-label {
-        font-size: 11px;
-      }
-
-      #ma-controls {
-        top: 46px;
-        left: 5px;
-        padding: 6px 10px;
-        gap: 8px;
-      }
-
-      .ma-toggle { font-size: 11px; }
+      #timeframe-controls { top: 5px; left: 5px; padding: 6px 10px; }
+      #timeframe-dropdown { font-size: 11px; padding: 4px 8px; min-width: 70px; }
+      .timeframe-label { font-size: 11px; }
+      #tools-button { top: 5px; right: 5px; padding: 6px 8px; font-size: 11px; }
+      #tools-panel { top: 44px; right: 5px; width: 230px; }
     }
-    
     @media (max-width: 480px) {
-      #timeframe-controls {
-        padding: 4px 8px;
-      }
-      
-      #timeframe-dropdown {
-        font-size: 10px;
-        padding: 3px 6px;
-        min-width: 60px;
-      }
-      
-      .timeframe-label {
-        font-size: 10px;
-      }
-
-      #ma-controls {
-        top: 42px;
-        padding: 4px 8px;
-      }
-
-      .ma-toggle { font-size: 10px; }
+      #timeframe-controls { padding: 4px 8px; }
+      #timeframe-dropdown { font-size: 10px; padding: 3px 6px; min-width: 60px; }
+      .timeframe-label { font-size: 10px; }
+      #tools-button { padding: 5px 7px; font-size: 10px; }
+      #tools-panel { top: 40px; width: 220px; }
     }
   </style>
 </head>
@@ -178,27 +174,37 @@
       </select>
     </div>
 
-    <div id="ma-controls">
-      <label class="ma-toggle" title="Toggle MA20 visibility">
-        <input type="checkbox" id="toggle-ma20" checked />
-        <span class="ma-swatch" style="background:#00BFFF"></span>
-        MA20
-      </label>
-      <label class="ma-toggle" title="Toggle MA50 visibility">
-        <input type="checkbox" id="toggle-ma50" checked />
-        <span class="ma-swatch" style="background:#FF6B6B"></span>
-        MA50
-      </label>
-      <label class="ma-toggle" title="Toggle MA100 visibility">
-        <input type="checkbox" id="toggle-ma100" checked />
-        <span class="ma-swatch" style="background:#4ADF86"></span>
-        MA100
-      </label>
-      <label class="ma-toggle" title="Toggle MA200 visibility">
-        <input type="checkbox" id="toggle-ma200" checked />
-        <span class="ma-swatch" style="background:#FFD700"></span>
-        MA200
-      </label>
+    <button id="tools-button" type="button">Tools ▾</button>
+
+    <div id="tools-panel">
+      <div class="panel-section">
+        <div class="panel-title">Moving Averages</div>
+        <label class="ma-toggle"><input type="checkbox" id="toggle-ma20" checked /><span class="ma-swatch" style="background:#00BFFF"></span>MA20</label>
+        <label class="ma-toggle"><input type="checkbox" id="toggle-ma50" checked /><span class="ma-swatch" style="background:#FF6B6B"></span>MA50</label>
+        <label class="ma-toggle"><input type="checkbox" id="toggle-ma100" checked /><span class="ma-swatch" style="background:#4ADF86"></span>MA100</label>
+        <label class="ma-toggle"><input type="checkbox" id="toggle-ma200" checked /><span class="ma-swatch" style="background:#FFD700"></span>MA200</label>
+      </div>
+
+      <div class="panel-section">
+        <div class="panel-title">Timeframes</div>
+        <div class="btn-row">
+          <button class="btn" data-timeframe="1m">1m</button>
+          <button class="btn" data-timeframe="5m">5m</button>
+          <button class="btn" data-timeframe="15m">15m</button>
+          <button class="btn" data-timeframe="1h">1h</button>
+          <button class="btn" data-timeframe="4h">4h</button>
+          <button class="btn" data-timeframe="1d">1d</button>
+        </div>
+      </div>
+
+      <div class="panel-section">
+        <div class="panel-title">Tools</div>
+        <div class="btn-row">
+          <button id="btn-measure" class="btn">Measure</button>
+          <button id="btn-add-hline" class="btn">Add H-Line</button>
+          <button id="btn-clear-hlines" class="btn btn-danger">Clear H-Lines</button>
+        </div>
+      </div>
     </div>
     
     <div id="main-chart"></div>
@@ -206,5 +212,36 @@
   
   <script src="https://unpkg.com/lightweight-charts@4.0.0/dist/lightweight-charts.standalone.production.js"></script>
   <script src="chart.js"></script>
+  <script>
+    // Simple toggling of the tools panel without interfering with chart interactions
+    (function() {
+      const btn = document.getElementById('tools-button');
+      const panel = document.getElementById('tools-panel');
+
+      function closePanelOnOutsideClick(e) {
+        if (!panel.contains(e.target) && e.target !== btn) {
+          panel.style.display = 'none';
+          document.removeEventListener('mousedown', closePanelOnOutsideClick);
+        }
+      }
+
+      btn.addEventListener('click', () => {
+        const visible = panel.style.display === 'block';
+        panel.style.display = visible ? 'none' : 'block';
+        if (!visible) {
+          setTimeout(() => document.addEventListener('mousedown', closePanelOnOutsideClick), 0);
+        }
+      });
+
+      // Timeframe quick buttons delegate to global setTimeframe()
+      panel.addEventListener('click', (e) => {
+        const t = e.target;
+        if (t.matches('button[data-timeframe]')) {
+          const tf = t.getAttribute('data-timeframe');
+          if (window.setTimeframe) window.setTimeframe(tf);
+        }
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
 
     #indicator-chart {
       width: 100%;
-      height: 28%;
+      height: 20%;
       display: none; /* toggled on via JS */
       border-top: 1px solid rgba(255,255,255,0.08);
       position: relative;
@@ -288,6 +288,16 @@
           window.toggleIndicatorPanel();
         }
       });
+
+      // Add a direct listener to maximize compatibility
+      const indBtn = document.getElementById('btn-toggle-indicator');
+      if (indBtn) {
+        indBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (window.toggleIndicatorPanel) window.toggleIndicatorPanel();
+        });
+      }
     })();
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -26,12 +26,41 @@
       width: 100vw;
       height: 100vh;
       position: relative;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Stack main and indicator charts vertically */
+    #charts-stack {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      width: 100%;
     }
     
     #main-chart {
       width: 100%;
-      height: 100%;
+      flex: 1 1 auto;
       touch-action: pan-x pan-y pinch-zoom;
+    }
+
+    #indicator-chart {
+      width: 100%;
+      height: 28%;
+      display: none; /* toggled on via JS */
+      border-top: 1px solid rgba(255,255,255,0.08);
+      position: relative;
+    }
+
+    #indicator-placeholder {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      color: #9aa0a6;
+      font-size: 12px;
+      pointer-events: none;
+      opacity: 0.8;
     }
     
     #timeframe-controls {
@@ -105,7 +134,7 @@
       top: 50px;
       right: 10px;
       z-index: 120;
-      width: 240px;
+      width: 260px;
       background: rgba(25,28,35,0.98);
       border: 1px solid rgba(255,255,255,0.1);
       border-radius: 10px;
@@ -115,9 +144,7 @@
       backdrop-filter: blur(8px);
     }
 
-    .panel-section {
-      margin-bottom: 10px;
-    }
+    .panel-section { margin-bottom: 10px; }
     .panel-title {
       color: #9aa0a6;
       font-size: 11px;
@@ -152,14 +179,14 @@
       #timeframe-dropdown { font-size: 11px; padding: 4px 8px; min-width: 70px; }
       .timeframe-label { font-size: 11px; }
       #tools-button { top: 5px; right: 5px; padding: 6px 8px; font-size: 11px; }
-      #tools-panel { top: 44px; right: 5px; width: 230px; }
+      #tools-panel { top: 44px; right: 5px; width: 250px; }
     }
     @media (max-width: 480px) {
       #timeframe-controls { padding: 4px 8px; }
       #timeframe-dropdown { font-size: 10px; padding: 3px 6px; min-width: 60px; }
       .timeframe-label { font-size: 10px; }
       #tools-button { padding: 5px 7px; font-size: 10px; }
-      #tools-panel { top: 40px; width: 220px; }
+      #tools-panel { top: 40px; width: 240px; }
     }
   </style>
 </head>
@@ -210,9 +237,21 @@
           <button id="btn-clear-vlines" class="btn btn-danger">Clear V-Lines</button>
         </div>
       </div>
+
+      <div class="panel-section">
+        <div class="panel-title">Indicator Panel</div>
+        <div class="btn-row">
+          <button id="btn-toggle-indicator" class="btn">Toggle Indicator Panel</button>
+        </div>
+      </div>
     </div>
-    
-    <div id="main-chart"></div>
+
+    <div id="charts-stack">
+      <div id="main-chart"></div>
+      <div id="indicator-chart">
+        <div id="indicator-placeholder">Indicator Panel (placeholder)</div>
+      </div>
+    </div>
   </div>
   
   <script src="https://unpkg.com/lightweight-charts@4.0.0/dist/lightweight-charts.standalone.production.js"></script>
@@ -244,6 +283,9 @@
         if (t.matches('button[data-timeframe]')) {
           const tf = t.getAttribute('data-timeframe');
           if (window.setTimeframe) window.setTimeframe(tf);
+        }
+        if (t.id === 'btn-toggle-indicator' && window.toggleIndicatorPanel) {
+          window.toggleIndicatorPanel();
         }
       });
     })();

--- a/index.html
+++ b/index.html
@@ -78,6 +78,9 @@
       font-weight: 500;
     }
 
+    /* Hide legacy timeframe control */
+    #timeframe-controls { display: none !important; }
+
     /* Floating Tools Button */
     #tools-button {
       position: absolute;
@@ -202,7 +205,9 @@
         <div class="btn-row">
           <button id="btn-measure" class="btn">Measure</button>
           <button id="btn-add-hline" class="btn">Add H-Line</button>
+          <button id="btn-add-vline" class="btn">Add V-Line</button>
           <button id="btn-clear-hlines" class="btn btn-danger">Clear H-Lines</button>
+          <button id="btn-clear-vlines" class="btn btn-danger">Clear V-Lines</button>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
       display: none; /* toggled on via JS */
       border-top: 1px solid rgba(255,255,255,0.08);
       position: relative;
+      background: #0f131a;
     }
 
     #indicator-placeholder {


### PR DESCRIPTION
Add individual toggle controls for MA20, MA50, MA100, and MA200 displays on the chart to allow users to customize visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-a200d590-1734-4ec2-882d-b18b6261aa9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a200d590-1734-4ec2-882d-b18b6261aa9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

